### PR TITLE
Fix wrong VK_CALLBACK_URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 ```
 VK_APP_ID: "ваш app id"
 VK_APP_KEY: "ваш app key""
-VK_CALLBACK_URL: "http:/localhost:3000/users/auth/vkontakte/callback"
+VK_CALLBACK_URL: "http://localhost:3000/users/auth/vkontakte/callback"
 ```
 
 для разработки на локальном сервере необходимо войти в учетку вк и создать там приложение:
 `http://vk.com/editapp?act=create`
 
-Далее в настройках приложения в полях "адрес сайта" и "базовый домен" указать тот адрес, на котором у вас запущен сервер, например 
+Далее в настройках приложения в полях "адрес сайта" и "базовый домен" указать тот адрес, на котором у вас запущен сервер, например
 `http://localhost:3000`
 
-В поле "доверенный redirect URI" указать тот же самый url, который указан в настройках приложения по ключу 'VK_CALLBACK_URL', например 
-`http:/localhost:3000/users/auth/vkontakte/callback`
+В поле "доверенный redirect URI" указать тот же самый url, который указан в настройках приложения по ключу 'VK_CALLBACK_URL', например
+`http://localhost:3000/users/auth/vkontakte/callback`
 
 файл уже добавлен в .gitignore.


### PR DESCRIPTION
Rename file contains wrong `VK_CALLBACK_URL` it should be `http://...` 
Sign up through VK dosen't work with this URL
