### PR TITLE
Add tests to factories and traits

### DIFF
--- a/spec/factories/factories_spec.rb
+++ b/spec/factories/factories_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Factory Girl" do
+  FactoryGirl.factories.map(&:name).each do |factory_name|
+    describe "#{factory_name} factory" do
+      it "is valid", factory: true do
+        factory = FactoryGirl.build(factory_name)
+        if factory.respond_to?(:valid?)
+          expect(factory).to be_valid, lambda { factory.errors.full_messages.join("\n") }
+        end
+      end
+
+      FactoryGirl.factories[factory_name].definition.defined_traits.map(&:name).each do |trait_name|
+        context "with trait #{trait_name}" do
+          it "is valid", factory: true do
+            factory = FactoryGirl.build(factory_name, trait_name)
+            if factory.respond_to?(:valid?)
+              expect(factory).to be_valid, lambda { factory.errors.full_messages.join("\n") }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/tags.rb
+++ b/spec/support/tags.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.filter_run_excluding factory: true
+end


### PR DESCRIPTION
Add tag for factories tests which false by default

Я столкнулся с небольшой проблемой при написании тестов к своему таску, и мне для отладки понадобились тесты фабрик, которые, думаю, будет не лишним добавить и в мастер по умолчанию они выключены, но если их нужно запустить то можно просто прописать `rspec --tag factory`