### PR TITLE
Add Factorygirl.lint

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,8 @@ require_relative 'support/controller_helpers'
 require 'devise'
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
   config.include ControllerHelpers, type: :controller
-  
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,14 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
+end


### PR DESCRIPTION
Remove FactoryGirl syntax config from spec_helper.rb to support/factory_girl.rb

Всесто спеков на фабрики как оказалось лучше использовать более новую фичу FactoryGirl.lint теперь при запуске тестов сначала будет проверятся валидность фабрик и только в случае успеха будут запускатся тесты. ПР Add tests to factories and traits я закрыл