### PR TITLE
Add admin, organizer, moderator test users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'paperclip'
 gem 'faker'
 gem 'will_paginate'
 gem 'will_paginate-materialize'
+gem 'factory_girl_rails'
 
 group :development, :test do
   #DB
@@ -27,7 +28,6 @@ group :test do
   gem 'selenium-webdriver', '~> 2.53'
   gem 'capybara', '~> 2.6', '>= 2.6.2'
   gem 'libnotify', '~> 0.9.1'
-  gem 'factory_girl_rails'
   gem 'shoulda'
   gem 'cucumber-rails', :require => false
   gem 'database_cleaner'

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ VK_CALLBACK_URL: "http://localhost:3000/users/auth/vkontakte/callback"
 файл уже добавлен в .gitignore.
 
 Для заполнения БД фейковыми данными `rake db:seed`, для создания списка городов затем `rake db:populate`.
+
+Это даст трех пользователей с разными ролями `[admin, organizer, moderator]@foo.bar` соответственно. Пароль `12345678`

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :group do
     city
     sequence(:name) { |i| "group name #{i}"}
-    description "new group description"
+    description { Faker::Hipster.sentence(5, true, 5) }
     trait :enabled do
       enabled true
     end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,8 +1,12 @@
 FactoryGirl.define do
   factory :purchase do
-    name 'Yet another purchase'
-    description 'My very new purchase'
+    name { Faker::Commerce.product_name }
+    description { Faker::Hipster.sentence(3, true, 4) }
     end_date { 5.days.from_now }
+
+    trait :opened do
+      status :opened
+    end
 
     factory :opened_purchase do
       status :opened

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,21 @@
 FactoryGirl.define do
   factory :user do
-    sequence(:email) { |n| "person#{n}@example.com" }
+    email { Faker::Internet.email }
     password "11111111"
-    username "Test User"
-    phone "123-123-123"
+    username { Faker::Name.name }
+    phone { Faker::PhoneNumber.cell_phone }
+
+    trait :admin do
+      after(:create) {|user| user.add_role(:organizer)}
+    end
+
+    trait :moderator do
+      after(:create) {|user| user.add_role(:organizer)}
+    end
+
+    trait :organizer do
+      after(:create) {|user| user.add_role(:organizer)}
+    end
 
     trait :organizer do
       after(:create) {|user| user.add_role(:organizer)}


### PR DESCRIPTION
Fake data based on factories
Factories use faker for more lifelike data

Сделал чтобы populate был основан на фабриках, чтобы в случае изменения моделей не приходилось менять `db:populate`. 
Добавил трех тестовых пользователей с разными ролями для тестов `[admin, organizer, moderator]@foo.bar` пароль у всех `12345678`
Вместо подфабрик лучше использовать трейты [здесь](https://robots.thoughtbot.com/remove-duplication-with-factorygirls-traits) написано почему