### PR TITLE
Config capybara-webkit for js specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem 'headless'
   gem 'capybara'
   gem 'poltergeist'
+  gem 'capybara-webkit'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     ckeditor (4.2.0)
       cocaine
       orm_adapter (~> 0.5.0)
@@ -399,6 +402,7 @@ DEPENDENCIES
   binding_of_caller
   cancancan (~> 1.10)
   capybara
+  capybara-webkit
   ckeditor
   cloudinary
   coffee-rails (~> 4.1, >= 4.1.1)

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 require 'capybara/poltergeist'
 
 RSpec.configure do |config|
-  Capybara.javascript_driver = :poltergeist
-  options = {js_errors: false}
-  Capybara.register_driver :poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, options)
+  Capybara.javascript_driver = :webkit
+  Capybara::Webkit.configure do |config|
+    config.allow_url('www.gravatar.com')
+    config.allow_url('fonts.googleapis.com')
   end
+
   Capybara.ignore_hidden_elements = false
   config.use_transactional_fixtures = false
 

--- a/spec/features/search_purchases_spec.rb
+++ b/spec/features/search_purchases_spec.rb
@@ -11,7 +11,7 @@ feature 'Search purchases' do
     visit purchases_path
   end
 
-  xscenario 'by name', js: true do
+  scenario 'by name', js: true do
     fill_in 'grid_f_name', with: purchase.name
     click_on 'search'
     expect(page).to have_link(purchase.name)


### PR DESCRIPTION
В общем проблема падающего теста похоже находиться где-то в программе phantomjs от которой работает js спек драйвер poltergeist. В версии 2.2 тест проходит без проблем, но на Travis предустановлена 1.9
_Мое предложение_ использовать для js тестов capybara-webkit с ним вроде никаких проблем нету.